### PR TITLE
[Featt] New Decks and increase randomization

### DIFF
--- a/src/views/FoodDrawPage.vue
+++ b/src/views/FoodDrawPage.vue
@@ -55,15 +55,15 @@ import DrawCard from '@/components/draw/DrawCard.vue'
 
 const route = useRoute()
 const yelpApi = inject('yelpApi')
-const state = reactive({ restaurants: [], draw: [] })
+const state = reactive({ restaurants: [], remainingOptions: [], draw: [] })
 
 yelpApi
   .get('/yelp', {
     params: { location: route.query.location, terms: 'restaurant' }
   })
   .then(({ data }) => {
-    state.restaurants = data.businesses
-    state.draw = [...state.restaurants]
+    state.restaurants = data
+    constructRandomDeck()
   })
 
 let winner = reactive({})
@@ -71,12 +71,11 @@ function drawRestaurants() {
   // remove half of the items randomly
   let i = 0
   const itemsToRemove = state.draw.length / 2
-  while (i < itemsToRemove) {
+  for (let i = 0; i < itemsToRemove; ++i) {
     const index = selectRandomIndex()
     state.draw.splice(index, 1)
-    ++i
-    if (state.draw.length <= 1) winner = state.draw[0]
   }
+  if (state.draw.length <= 1) winner = state.draw[0]
 }
 
 function selectRandomIndex() {
@@ -84,8 +83,19 @@ function selectRandomIndex() {
   return Math.floor(Math.random() * (max + 1))
 }
 
+function constructRandomDeck() {
+  state.draw = []
+  state.remainingOptions = [...state.restaurants]
+  for (let i = 0; i < state.restaurants.length / 2.5; ++i) {
+    const position = selectRandomIndex()
+    const randomCard = state.remainingOptions[position]
+    state.draw.push(randomCard)
+    state.remainingOptions.splice(position, 1)
+  }
+}
+
 function resetGame() {
-  state.draw = [...state.restaurants]
+  constructRandomDeck()
   winner = {}
 }
 </script>


### PR DESCRIPTION
The purpose of this MR is to increase the randomization by creating new decks. The backend returns 50 entries now. From that 50, half of those options are selected at random. Thus each time the game is played, a new deck of options are selected from those 50 items. This process occurs when the page loads, the game is reset, or a winner has been selected